### PR TITLE
Force Spree.user_class#spree_roles to use has_many instead of HABTM

### DIFF
--- a/lib/shopping_mall/engine.rb
+++ b/lib/shopping_mall/engine.rb
@@ -14,5 +14,19 @@ module ShoppingMall
     end
 
     config.to_prepare(&method(:activate).to_proc)
+
+    initializer "shopping_mall.user_roles" do
+      Spree.user_class.class_eval do
+        # Unfortunately, since `Spree.user_class#spree_roles is a HABTM
+        # association, it won't work with apartment / shopping_mall
+        #
+        # This also won't work if it resides on app/models/user_decorator.rb
+        # because it gets eval'ed (above in `.activate`) *after* Spree Core
+        # adds extensions to Spree.user_class
+        def spree_roles
+          roles
+        end
+      end
+    end
   end
 end

--- a/lib/shopping_mall/version.rb
+++ b/lib/shopping_mall/version.rb
@@ -1,3 +1,3 @@
 module ShoppingMall
-  VERSION = '0.0.3'
+  VERSION = '0.0.4'
 end


### PR DESCRIPTION
This ensures that accessing admin areas works correctly regardless of
which tenant is active. Previously `#spree_roles` was handled via HABTM
association and was therefore causing queries on the spree_users_roles
table to never be scoped to the public schema.